### PR TITLE
Adding two new flags to TreeMux, RedirectTrailingSlash & RedirectCleanPa...

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Go's http.ServeContent and related functions already handle the HEAD method corr
 The router has special handling for paths with trailing slashes. If a pattern is added to the router with a trailing slash, any matches on that pattern without a trailing slash will be redirected to the version with the slash. If a pattern does not have a trailing slash, matches on that pattern with a trailing slash will be redirected to the version without.
 
 The trailing slash flag is only stored once for a pattern. That is, if a pattern is added for a method with a trailing slash, all other methods for that pattern will also be considered to have a trailing slash, regardless of whether or not it is specified for those methods too.
+However this behavior can be turned off by setting TreeMux.RedirectTrailingSlash to false. By default it is set to true.
 
 ```go
 router = httptreemux.New()

--- a/router_test.go
+++ b/router_test.go
@@ -258,6 +258,35 @@ func TestRedirect(t *testing.T) {
 
 }
 
+func TestSkipRedirect(t *testing.T) {
+	router := New()
+	router.RedirectTrailingSlash = false
+	router.RedirectCleanPath = false
+	router.GET("/slash/", simpleHandler)
+	router.GET("/noslash", simpleHandler)
+
+	w := httptest.NewRecorder()
+	r := newRequest("GET", "/slash", nil)
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("/slash expected code 404, saw %d", w.Code)
+	}
+
+	r = newRequest("GET", "/noslash/", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("/noslash/ expected code 404, saw %d", w.Code)
+	}
+
+	r = newRequest("GET", "//noslash", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("//noslash expected code 404, saw %d", w.Code)
+	}
+}
+
 func TestRoot(t *testing.T) {
 	handlerCalled := false
 	handler := func(w http.ResponseWriter, r *http.Request, params map[string]string) {


### PR DESCRIPTION
...th. By setting RedirectTrailingSlash to false, we will disable the redirection on Trailing Slash. Also by setting RedirectCleanPath to false, router will not try to clean the path. By default both these flags are set to true