### PR TITLE
Added router group functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ Path elements starting with : indicate a wildcard in the path. A wildcard will o
 
 A path element starting with * is a catch-all, whose value will be a string containing all text in the URL matched by the wildcards. For example, with a pattern of `/images/*path` and a requested URL `images/abc/def`, path would contain `abc/def`.
 
+## Routing Groups
+Lets you create a new group of routes with a given path prefix.  Makes it easier to create clusters of paths like:
+* /api/v1/foo
+* /api/v1/bar
+
+To use this you do:
+```go
+router = httptreemux.New()
+api := router.NewGroup("/api/v1")
+api.GET("/foo", fooHanler) // becomes /api/v1/foo
+api.GET("/bar", barHandler) // becomes /api/v1/bar
+```
+
 ### Routing Priority
 The priority rules in the router are simple.
 

--- a/group.go
+++ b/group.go
@@ -1,0 +1,58 @@
+package httptreemux
+
+import (
+	"fmt"
+)
+
+type Group struct {
+	path string
+	mux  *TreeMux
+}
+
+func (t *TreeMux) NewGroup(path string) *Group {
+	checkPath(path)
+	//Don't want trailing slash as all sub-paths start with slash
+	if path[len(path)-1] == '/' {
+		path = path[:len(path)-1]
+	}
+	return &Group{path, t}
+}
+
+// Add a sub-group to this group
+func (g *Group) NewGroup(path string) *Group {
+	checkPath(path)
+	return g.mux.NewGroup(g.path + path)
+}
+
+func (g *Group) Handle(method string, path string, handler HandlerFunc) {
+	checkPath(path)
+	g.mux.Handle(method, g.path+path, handler)
+}
+
+func (g *Group) GET(path string, handler HandlerFunc) {
+	g.Handle("GET", path, handler)
+}
+func (g *Group) POST(path string, handler HandlerFunc) {
+	g.Handle("POST", path, handler)
+}
+func (g *Group) PUT(path string, handler HandlerFunc) {
+	g.Handle("PUT", path, handler)
+}
+func (g *Group) DELETE(path string, handler HandlerFunc) {
+	g.Handle("DELETE", path, handler)
+}
+func (g *Group) PATCH(path string, handler HandlerFunc) {
+	g.Handle("PATCH", path, handler)
+}
+func (g *Group) HEAD(path string, handler HandlerFunc) {
+	g.Handle("HEAD", path, handler)
+}
+func (g *Group) OPTIONS(path string, handler HandlerFunc) {
+	g.Handle("OPTIONS", path, handler)
+}
+
+func checkPath(path string) {
+	if path[0] != '/' {
+		panic(fmt.Sprintf("Path %s must start with slash", path))
+	}
+}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,66 @@
+package httptreemux
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGroupMethods(t *testing.T) {
+	for _, scenario := range scenarios {
+		t.Log(scenario.description)
+		testGroupMethods(t, scenario.RequestCreator)
+	}
+}
+
+//Liberally borrowed from router_test
+func testGroupMethods(t *testing.T, reqGen RequestCreator) {
+	var result string
+	makeHandler := func(method string) HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+			result = method
+		}
+	}
+	router := New()
+	// Testing with a sub-group of a group as that will test everything at once
+	g := router.NewGroup("/base").NewGroup("/user")
+	g.GET("/:param", makeHandler("GET"))
+	g.POST("/:param", makeHandler("POST"))
+	g.PATCH("/:param", makeHandler("PATCH"))
+	g.PUT("/:param", makeHandler("PUT"))
+	g.DELETE("/:param", makeHandler("DELETE"))
+
+	testMethod := func(method, expect string) {
+		result = ""
+		w := httptest.NewRecorder()
+		r, _ := reqGen(method, "/base/user/"+method, nil)
+		router.ServeHTTP(w, r)
+		if expect == "" && w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("Method %s not expected to match but saw code %d", w.Code)
+		}
+
+		if result != expect {
+			t.Errorf("Method %s got result %s", method, result)
+		}
+	}
+
+	testMethod("GET", "GET")
+	testMethod("POST", "POST")
+	testMethod("PATCH", "PATCH")
+	testMethod("PUT", "PUT")
+	testMethod("DELETE", "DELETE")
+	t.Log("Test HeadCanUseGet = true")
+	testMethod("HEAD", "GET")
+
+	router.HeadCanUseGet = false
+	t.Log("Test HeadCanUseGet = false")
+	testMethod("HEAD", "")
+
+	router.HEAD("/base/user/:param", makeHandler("HEAD"))
+
+	t.Log("Test HeadCanUseGet = false with explicit HEAD handler")
+	testMethod("HEAD", "HEAD")
+	router.HeadCanUseGet = true
+	t.Log("Test HeadCanUseGet = true with explicit HEAD handler")
+	testMethod("HEAD", "HEAD")
+}


### PR DESCRIPTION
Routing groups let you create a new group of routes with a given path prefix.
Simplifies creating clusters of paths.

This addresses #21, but with a slightly more flexible api.