### PR TITLE
Groups were not validating that sub-paths started with a / 

### DIFF
--- a/group.go
+++ b/group.go
@@ -11,8 +11,8 @@ type Group struct {
 
 // Add a sub-group to this group
 func (g *Group) NewGroup(path string) *Group {
-	path = g.path + path
 	checkPath(path)
+	path = g.path + path
 	//Don't want trailing slash as all sub-paths start with slash
 	if path[len(path)-1] == '/' {
 		path = path[:len(path)-1]

--- a/group.go
+++ b/group.go
@@ -83,8 +83,8 @@ func (g *Group) NewGroup(path string) *Group {
 // 	GET /posts/ will match normally.
 // 	POST /posts will redirect to /posts/, because the GET method used a trailing slash.
 func (g *Group) Handle(method string, path string, handler HandlerFunc) {
-	path = g.path + path
 	checkPath(path)
+	path = g.path + path
 
 	addSlash := false
 	if len(path) > 1 && path[len(path)-1] == '/' && g.mux.RedirectTrailingSlash {

--- a/group_test.go
+++ b/group_test.go
@@ -13,6 +13,24 @@ func TestGroupMethods(t *testing.T) {
 	}
 }
 
+func TestInvalidSubPath(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Error("Bad sub-path should have caused a panic")
+		}
+	}()
+	New().NewGroup("/foo").NewGroup("bar")
+}
+
+func TestInvalidPath(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Error("Bad path should have caused a panic")
+		}
+	}()
+	New().NewGroup("foo")
+}
+
 //Liberally borrowed from router_test
 func testGroupMethods(t *testing.T, reqGen RequestCreator) {
 	var result string

--- a/group_test.go
+++ b/group_test.go
@@ -13,6 +13,15 @@ func TestGroupMethods(t *testing.T) {
 	}
 }
 
+func TestInvalidHandle(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Error("Bad handle path should have caused a panic")
+		}
+	}()
+	New().NewGroup("/foo").GET("bar", nil)
+}
+
 func TestInvalidSubPath(t *testing.T) {
 	defer func() {
 		if err := recover(); err == nil {


### PR DESCRIPTION
When you created a sub-group or handler off a group, the path was not being properly checked, allowing one to things like:

New().NewGroup("/foo").NewGroup("bar"), giving you /foobar as the group.
New().NewGroup("/foo").GET("bar",...), causing the url to be /foobar

The cause was that we concatenated the parent path first before checking to see if "path" started with a forward slash.  

this change ensures that the specified path to NewGroup and Handle starts with a forward slash
