### PR TITLE
Add ability to map root of subgroup

### DIFF
--- a/group.go
+++ b/group.go
@@ -84,11 +84,11 @@ func (g *Group) NewGroup(path string) *Group {
 // 	POST /posts will redirect to /posts/, because the GET method used a trailing slash.
 func (g *Group) Handle(method string, path string, handler HandlerFunc) {
 	checkPath(path)
-	if path == "/" && len(g.path) > 0 {
+
+	if path == "/" && len(g.path) > 0 { // root of subgroup should map to subgroup's path
 		path = g.path
 	} else {
 		path = g.path + path
-
 	}
 
 	addSlash := false

--- a/group.go
+++ b/group.go
@@ -84,7 +84,12 @@ func (g *Group) NewGroup(path string) *Group {
 // 	POST /posts will redirect to /posts/, because the GET method used a trailing slash.
 func (g *Group) Handle(method string, path string, handler HandlerFunc) {
 	checkPath(path)
-	path = g.path + path
+	if path == "/" && len(g.path) > 0 {
+		path = g.path
+	} else {
+		path = g.path + path
+
+	}
 
 	addSlash := false
 	if len(path) > 1 && path[len(path)-1] == '/' && g.mux.RedirectTrailingSlash {

--- a/group.go
+++ b/group.go
@@ -11,6 +11,10 @@ type Group struct {
 
 // Add a sub-group to this group
 func (g *Group) NewGroup(path string) *Group {
+	if len(path) < 1 {
+		panic("Group path must not be empty")
+	}
+
 	checkPath(path)
 	path = g.path + path
 	//Don't want trailing slash as all sub-paths start with slash
@@ -84,13 +88,10 @@ func (g *Group) NewGroup(path string) *Group {
 // 	POST /posts will redirect to /posts/, because the GET method used a trailing slash.
 func (g *Group) Handle(method string, path string, handler HandlerFunc) {
 	checkPath(path)
-
-	if path == "/" && len(g.path) > 0 { // root of subgroup should map to subgroup's path
-		path = g.path
-	} else {
-		path = g.path + path
+	path = g.path + path
+	if len(path) == 0 {
+		panic("Cannot map an empty path")
 	}
-
 	addSlash := false
 	if len(path) > 1 && path[len(path)-1] == '/' && g.mux.RedirectTrailingSlash {
 		addSlash = true
@@ -140,7 +141,8 @@ func (g *Group) OPTIONS(path string, handler HandlerFunc) {
 }
 
 func checkPath(path string) {
-	if path[0] != '/' {
+	// All non-empty paths must start with a slash
+	if len(path) > 0 && path[0] != '/' {
 		panic(fmt.Sprintf("Path %s must start with slash", path))
 	}
 }

--- a/group_test.go
+++ b/group_test.go
@@ -6,6 +6,19 @@ import (
 	"testing"
 )
 
+func TestMapMethodToRoot(t *testing.T) {
+	called := false
+	r := New()
+	r.NewGroup("/foo").GET("/", func(_ http.ResponseWriter, _ *http.Request, _ map[string]string) {
+		called = true
+	})
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	if !called {
+		t.Error("Root of subgroup should map to subgroup's URL and NOT redirect you to GROUP/")
+	}
+}
+
 func TestGroupMethods(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Log(scenario.description)


### PR DESCRIPTION
There was a bug in the initial implementation of subgroups where mapping the root of a subgroup ended up in adding the "add trailing slash" logic.

This code basically changes it so if you do subGroup.Handle("/",...) then we just use the subgroups original path.

This change maps:
router.NewGroup("/foo").GET("/") -> /foo (no trailing slash added)

before this change it did:
/foo (with add trailing slash enabled)

