### PR TITLE
Added http.HandlerFunc support when using Go 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,14 @@ router.GET("/:year/:month", archiveHandler)
 router.GET("/images/*path", staticHandler)
 router.GET("/favicon.ico", staticHandler)
 
-/abc will match /:page
-/2014/05 will match /:year/:month
-/2014/05/really-great-blog-post will match /:year/:month/:post
-/images/CoolImage.gif will match /images/*path
-/images/2014/05/MayImage.jpg will also match /images/*path, with all the text after /images stored in the variable path.
-/favicon.ico will match /favicon.ico
+/* 
+    /abc will match /:page
+    /2014/05 will match /:year/:month
+    /2014/05/really-great-blog-post will match /:year/:month/:post
+    /images/CoolImage.gif will match /images/*path
+    /images/2014/05/MayImage.jpg will also match /images/*path, with all the text after /images stored in the variable path.
+    /favicon.ico will match /favicon.ico
+*/
 ```
 
 ### Special Method Behavior

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ There are a lot of good routers out there. But looking at the ones that were rea
 ## Handler
 The handler is a simple function with the prototype `func(w http.ResponseWriter, r *http.Request, params map[string]string)`. The params argument contains the parameters parsed from wildcards and catch-alls in the URL, as described below. This type is aliased as httptreemux.HandlerFunc.
 
+### Using http.HandlerFunc
+Due to the inclusion of the [context](https://godoc.org/context) package as of Go 1.7, `httptreemux` now supports handlers of type [http.HandlerFunc](https://godoc.org/net/http#HandlerFunc):
+
+```go
+router := httptreemux.New()
+router.HandleWithContext("GET", "/hello/:name", func(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    params := httptreemux.ContextParams(ctx)
+    fmt.Fprintf(w, "Hello, %s!", params["name"])
+})
+```
+
 ## Routing Rules
 The syntax here is also modeled after httprouter. Each variable in a path may match on one segment only, except for an optional catch-all variable at the end of the URL.
 
@@ -171,7 +183,6 @@ When matching on parameters in a route, the `gorilla/pat` router will modify
 `Request.URL.RawQuery` to make it appear like the parameters were in the
 query string. `httptreemux` does not do this. See [Issue #26](https://github.com/dimfeld/httptreemux/issues/26) for more details and a
 code snippet that can perform this transformation for you, should you want it.
-
 
 ## Middleware
 This package provides no middleware. But there are a lot of great options out there and it's pretty easy to write your own.

--- a/context.go
+++ b/context.go
@@ -3,15 +3,15 @@
 package httptreemux
 
 import (
-    "context"
-    "net/http"
+	"context"
+	"net/http"
 )
 
 // ContextGroup is a wrapper around Group, with the purpose of mimicking its API, but with the use of http.HandlerFunc-based handlers.
 // Instead of passing a parameter map via the handler (i.e. httptreemux.HandlerFunc), the path parameters are accessed via the request
 // object's context.
 type ContextGroup struct {
-    group *Group
+	group *Group
 }
 
 // UsingContext wraps the receiver to return a new instance of a ContextGroup.
@@ -33,66 +33,66 @@ type ContextGroup struct {
 //              http.ListenAndServe(":8080", tree)
 //
 func (g *Group) UsingContext() *ContextGroup {
-    return &ContextGroup{g}
+	return &ContextGroup{g}
 }
 
 // NewContextGroup adds a child context group to its path.
 func (cg *ContextGroup) NewContextGroup(path string) *ContextGroup {
-    return &ContextGroup{cg.group.NewGroup(path)}
+	return &ContextGroup{cg.group.NewGroup(path)}
 }
 
 // Handle allows handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
 // Any parameters from the request URL are stored in via a map[string]string in the request's context.
 func (cg *ContextGroup) Handle(method, path string, handler http.HandlerFunc) {
-    cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-        if params != nil {
-            r = r.WithContext(context.WithValue(r.Context(), ParamsContextKey, params))
-        }
-        handler(w, r)
-    })
+	cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		if params != nil {
+			r = r.WithContext(context.WithValue(r.Context(), ParamsContextKey, params))
+		}
+		handler(w, r)
+	})
 }
 
 // GET is convenience method for handling GET requests on a context group.
 func (cg *ContextGroup) GET(path string, handler http.HandlerFunc) {
-    cg.Handle("GET", path, handler)
+	cg.Handle("GET", path, handler)
 }
 
 // POST is convenience method for handling POST requests on a context group.
 func (cg *ContextGroup) POST(path string, handler http.HandlerFunc) {
-    cg.Handle("POST", path, handler)
+	cg.Handle("POST", path, handler)
 }
 
 // PUT is convenience method for handling PUT requests on a context group.
 func (cg *ContextGroup) PUT(path string, handler http.HandlerFunc) {
-    cg.Handle("PUT", path, handler)
+	cg.Handle("PUT", path, handler)
 }
 
 // DELETE is convenience method for handling DELETE requests on a context group.
 func (cg *ContextGroup) DELETE(path string, handler http.HandlerFunc) {
-    cg.Handle("DELETE", path, handler)
+	cg.Handle("DELETE", path, handler)
 }
 
 // PATCH is convenience method for handling PATCH requests on a context group.
 func (cg *ContextGroup) PATCH(path string, handler http.HandlerFunc) {
-    cg.Handle("PATCH", path, handler)
+	cg.Handle("PATCH", path, handler)
 }
 
 // HEAD is convenience method for handling HEAD requests on a context group.
 func (cg *ContextGroup) HEAD(path string, handler http.HandlerFunc) {
-    cg.Handle("HEAD", path, handler)
+	cg.Handle("HEAD", path, handler)
 }
 
 // OPTIONS is convenience method for handling OPTIONS requests on a context group.
 func (cg *ContextGroup) OPTIONS(path string, handler http.HandlerFunc) {
-    cg.Handle("OPTIONS", path, handler)
+	cg.Handle("OPTIONS", path, handler)
 }
 
 // ContextParams returns the params map associated with the given context if one exists. Otherwise, an empty map is returned.
 func ContextParams(ctx context.Context) map[string]string {
-    if p, ok := ctx.Value(ParamsContextKey).(map[string]string); ok {
-        return p
-    }
-    return map[string]string{}
+	if p, ok := ctx.Value(ParamsContextKey).(map[string]string); ok {
+		return p
+	}
+	return map[string]string{}
 }
 
 // ParamsContextKey is used to retrieve a path's params map from a request's context.

--- a/context.go
+++ b/context.go
@@ -3,15 +3,15 @@
 package httptreemux
 
 import (
-	"context"
-	"net/http"
+    "context"
+    "net/http"
 )
 
-// ContextGroup is a wrapper around Group, with the purpose of mimicing its API, but with the use of http.HandlerFunc-based handlers.
+// ContextGroup is a wrapper around Group, with the purpose of mimicking its API, but with the use of http.HandlerFunc-based handlers.
 // Instead of passing a parameter map via the handler (i.e. httptreemux.HandlerFunc), the path parameters are accessed via the request
 // object's context.
 type ContextGroup struct {
-	group *Group
+    group *Group
 }
 
 // UsingContext wraps the receiver to return a new instance of a ContextGroup.
@@ -33,66 +33,66 @@ type ContextGroup struct {
 //              http.ListenAndServe(":8080", tree)
 //
 func (g *Group) UsingContext() *ContextGroup {
-	return &ContextGroup{g}
+    return &ContextGroup{g}
 }
 
 // NewContextGroup adds a child context group to its path.
 func (cg *ContextGroup) NewContextGroup(path string) *ContextGroup {
-	return &ContextGroup{cg.group.NewGroup(path)}
+    return &ContextGroup{cg.group.NewGroup(path)}
 }
 
 // Handle allows handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
 // Any parameters from the request URL are stored in via a map[string]string in the request's context.
 func (cg *ContextGroup) Handle(method, path string, handler http.HandlerFunc) {
-	cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		if params != nil {
-			r = r.WithContext(context.WithValue(r.Context(), ParamsContextKey, params))
-		}
-		handler(w, r)
-	})
+    cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+        if params != nil {
+            r = r.WithContext(context.WithValue(r.Context(), ParamsContextKey, params))
+        }
+        handler(w, r)
+    })
 }
 
 // GET is convenience method for handling GET requests on a context group.
 func (cg *ContextGroup) GET(path string, handler http.HandlerFunc) {
-	cg.Handle("GET", path, handler)
+    cg.Handle("GET", path, handler)
 }
 
 // POST is convenience method for handling POST requests on a context group.
 func (cg *ContextGroup) POST(path string, handler http.HandlerFunc) {
-	cg.Handle("POST", path, handler)
+    cg.Handle("POST", path, handler)
 }
 
 // PUT is convenience method for handling PUT requests on a context group.
 func (cg *ContextGroup) PUT(path string, handler http.HandlerFunc) {
-	cg.Handle("PUT", path, handler)
+    cg.Handle("PUT", path, handler)
 }
 
 // DELETE is convenience method for handling DELETE requests on a context group.
 func (cg *ContextGroup) DELETE(path string, handler http.HandlerFunc) {
-	cg.Handle("DELETE", path, handler)
+    cg.Handle("DELETE", path, handler)
 }
 
 // PATCH is convenience method for handling PATCH requests on a context group.
 func (cg *ContextGroup) PATCH(path string, handler http.HandlerFunc) {
-	cg.Handle("PATCH", path, handler)
+    cg.Handle("PATCH", path, handler)
 }
 
 // HEAD is convenience method for handling HEAD requests on a context group.
 func (cg *ContextGroup) HEAD(path string, handler http.HandlerFunc) {
-	cg.Handle("HEAD", path, handler)
+    cg.Handle("HEAD", path, handler)
 }
 
 // OPTIONS is convenience method for handling OPTIONS requests on a context group.
 func (cg *ContextGroup) OPTIONS(path string, handler http.HandlerFunc) {
-	cg.Handle("OPTIONS", path, handler)
+    cg.Handle("OPTIONS", path, handler)
 }
 
 // ContextParams returns the params map associated with the given context if one exists. Otherwise, an empty map is returned.
 func ContextParams(ctx context.Context) map[string]string {
-	if p, ok := ctx.Value(ParamsContextKey).(map[string]string); ok {
-		return p
-	}
-	return map[string]string{}
+    if p, ok := ctx.Value(ParamsContextKey).(map[string]string); ok {
+        return p
+    }
+    return map[string]string{}
 }
 
 // ParamsContextKey is used to retrieve a path's params map from a request's context.

--- a/context.go
+++ b/context.go
@@ -7,17 +7,82 @@ import (
 	"net/http"
 )
 
-// ParamsContextKey is used to retrieve a path's params map from a request's context.
-const ParamsContextKey = "params.context.key"
+type ContextTreeMux struct {
+	treemux       *TreeMux // cannot embed because TreeMux embeds Group, which prevents us from "overriding" Handle, which is also the reason we need a ContextTreeMux at all...
+	*ContextGroup          // embed because we want method inheritance
+}
 
-// HandleWithContext is a convenience method for handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
-func (g *Group) HandleWithContext(method, path string, handler http.HandlerFunc) {
-	g.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+func (t *TreeMux) UsingContext() *ContextTreeMux {
+	return &ContextTreeMux{treemux: t, ContextGroup: &ContextGroup{group: &(t.Group)}}
+}
+
+func (ct *ContextTreeMux) TreeMux() *TreeMux {
+	return ct.treemux
+}
+
+func (ct *ContextTreeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ct.TreeMux().ServeHTTP(w, r)
+}
+
+type ContextGroup struct {
+	group *Group // cannot embed Group because we want to "steal" its method signatures
+}
+
+func (g *Group) UsingContext() *ContextGroup {
+	return &ContextGroup{g}
+}
+
+func (cg *ContextGroup) NewContextGroup(path string) *ContextGroup {
+	return &ContextGroup{group: cg.Group().NewGroup(path)}
+}
+
+func (cg *ContextGroup) Group() *Group {
+	return cg.group
+}
+
+// Handle allows handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
+func (cg *ContextGroup) Handle(method, path string, handler http.HandlerFunc) {
+	cg.Group().Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 		if params != nil {
 			r = r.WithContext(context.WithValue(r.Context(), ParamsContextKey, params))
 		}
 		handler(w, r)
 	})
+}
+
+// Syntactic sugar for Handle("GET", path, handler)
+func (cg *ContextGroup) GET(path string, handler http.HandlerFunc) {
+	cg.Handle("GET", path, handler)
+}
+
+// Syntactic sugar for Handle("POST", path, handler)
+func (cg *ContextGroup) POST(path string, handler http.HandlerFunc) {
+	cg.Handle("POST", path, handler)
+}
+
+// Syntactic sugar for Handle("PUT", path, handler)
+func (cg *ContextGroup) PUT(path string, handler http.HandlerFunc) {
+	cg.Handle("PUT", path, handler)
+}
+
+// Syntactic sugar for Handle("DELETE", path, handler)
+func (cg *ContextGroup) DELETE(path string, handler http.HandlerFunc) {
+	cg.Handle("DELETE", path, handler)
+}
+
+// Syntactic sugar for Handle("PATCH", path, handler)
+func (cg *ContextGroup) PATCH(path string, handler http.HandlerFunc) {
+	cg.Handle("PATCH", path, handler)
+}
+
+// Syntactic sugar for Handle("HEAD", path, handler)
+func (cg *ContextGroup) HEAD(path string, handler http.HandlerFunc) {
+	cg.Handle("HEAD", path, handler)
+}
+
+// Syntactic sugar for Handle("OPTIONS", path, handler)
+func (cg *ContextGroup) OPTIONS(path string, handler http.HandlerFunc) {
+	cg.Handle("OPTIONS", path, handler)
 }
 
 // ContextParams returns the params map associated with the given context if one exists. Otherwise, an empty map is returned.
@@ -27,3 +92,6 @@ func ContextParams(ctx context.Context) map[string]string {
 	}
 	return map[string]string{}
 }
+
+// ParamsContextKey is used to retrieve a path's params map from a request's context.
+const ParamsContextKey = "params.context.key"

--- a/context.go
+++ b/context.go
@@ -1,0 +1,29 @@
+// +build go1.7
+
+package httptreemux
+
+import (
+	"context"
+	"net/http"
+)
+
+// ParamsContextKey is used to retrieve a path's params map from a request's context.
+const ParamsContextKey = "params.context.key"
+
+// HandleWithContext is a convenience method for handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
+func (g *Group) HandleWithContext(method, path string, handler http.HandlerFunc) {
+	g.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		if params != nil {
+			r = r.WithContext(context.WithValue(r.Context(), ParamsContextKey, params))
+		}
+		handler(w, r)
+	})
+}
+
+// ContextParams returns the params map associated with the given context if one exists. Otherwise, an empty map is returned.
+func ContextParams(ctx context.Context) map[string]string {
+	if p, ok := ctx.Value(ParamsContextKey).(map[string]string); ok {
+		return p
+	}
+	return map[string]string{}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,96 @@
+// +build go1.7
+
+package httptreemux
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestContextParams(t *testing.T) {
+	m := map[string]string{"id": "123"}
+	ctx := context.WithValue(context.Background(), ParamsContextKey, m)
+
+	params := ContextParams(ctx)
+	if params == nil {
+		t.Errorf("expected '%#v', but got '%#v'", m, params)
+	}
+
+	if v := params["id"]; v != "123" {
+		t.Errorf("expected '%s', but got '%#v'", m["id"], params["id"])
+	}
+
+}
+
+func TestHandleWithContext(t *testing.T) {
+	for _, scenario := range scenarios {
+		t.Log(scenario.description)
+		testHandleWithContext(t, scenario.RequestCreator, true)
+		testHandleWithContext(t, scenario.RequestCreator, false)
+	}
+}
+
+func testHandleWithContext(t *testing.T, reqGen RequestCreator, headCanUseGet bool) {
+	var result string
+	makeHandler := func(method string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			result = method
+
+			v, ok := ContextParams(r.Context())["param"]
+			if !ok {
+				t.Error("missing key 'param' in context")
+			}
+
+			if headCanUseGet && method == "GET" && v == "HEAD" {
+				return
+			}
+
+			if v != method {
+				t.Errorf("invalid key 'param' in context; expected '%s' but got '%s'", method, v)
+			}
+		}
+	}
+
+	router := New()
+	router.HeadCanUseGet = headCanUseGet
+
+	g := router.NewGroup("/base").NewGroup("/user")
+	g.HandleWithContext("GET", "/:param", makeHandler("GET"))
+	g.HandleWithContext("POST", "/:param", makeHandler("POST"))
+	g.HandleWithContext("PATCH", "/:param", makeHandler("PATCH"))
+	g.HandleWithContext("PUT", "/:param", makeHandler("PUT"))
+	g.HandleWithContext("DELETE", "/:param", makeHandler("DELETE"))
+
+	testMethod := func(method, expect string) {
+		result = ""
+		w := httptest.NewRecorder()
+		r, _ := reqGen(method, "/base/user/"+method, nil)
+		router.ServeHTTP(w, r)
+		if expect == "" && w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("Method %s not expected to match but saw code %d", method, w.Code)
+		}
+
+		if result != expect {
+			t.Errorf("Method %s got result %s", method, result)
+		}
+	}
+
+	testMethod("GET", "GET")
+	testMethod("POST", "POST")
+	testMethod("PATCH", "PATCH")
+	testMethod("PUT", "PUT")
+	testMethod("DELETE", "DELETE")
+
+	if headCanUseGet {
+		t.Log("Test implicit HEAD with HeadCanUseGet = true")
+		testMethod("HEAD", "GET")
+	} else {
+		t.Log("Test implicit HEAD with HeadCanUseGet = false")
+		testMethod("HEAD", "")
+	}
+
+	router.HandleWithContext("HEAD", "/base/user/:param", makeHandler("HEAD"))
+	testMethod("HEAD", "HEAD")
+}

--- a/context_test.go
+++ b/context_test.go
@@ -3,132 +3,131 @@
 package httptreemux
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
-	"testing"
+    "context"
+    "net/http"
+    "net/http/httptest"
+    "testing"
 )
 
 func TestContextParams(t *testing.T) {
-	m := map[string]string{"id": "123"}
-	ctx := context.WithValue(context.Background(), ParamsContextKey, m)
+    m := map[string]string{"id": "123"}
+    ctx := context.WithValue(context.Background(), ParamsContextKey, m)
 
-	params := ContextParams(ctx)
-	if params == nil {
-		t.Errorf("expected '%#v', but got '%#v'", m, params)
-	}
+    params := ContextParams(ctx)
+    if params == nil {
+        t.Errorf("expected '%#v', but got '%#v'", m, params)
+    }
 
-	if v := params["id"]; v != "123" {
-		t.Errorf("expected '%s', but got '%#v'", m["id"], params["id"])
-	}
-
+    if v := params["id"]; v != "123" {
+        t.Errorf("expected '%s', but got '%#v'", m["id"], params["id"])
+    }
 }
 
 func TestContextGroupMethods(t *testing.T) {
-	for _, scenario := range scenarios {
-		t.Log(scenario.description)
-		testContextGroupMethods(t, scenario.RequestCreator, true)
-		testContextGroupMethods(t, scenario.RequestCreator, false)
-	}
+    for _, scenario := range scenarios {
+        t.Log(scenario.description)
+        testContextGroupMethods(t, scenario.RequestCreator, true)
+        testContextGroupMethods(t, scenario.RequestCreator, false)
+    }
 }
 
 func testContextGroupMethods(t *testing.T, reqGen RequestCreator, headCanUseGet bool) {
-	var result string
-	makeHandler := func(method string) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			result = method
+    var result string
+    makeHandler := func(method string) http.HandlerFunc {
+        return func(w http.ResponseWriter, r *http.Request) {
+            result = method
 
-			v, ok := ContextParams(r.Context())["param"]
-			if !ok {
-				t.Error("missing key 'param' in context")
-			}
+            v, ok := ContextParams(r.Context())["param"]
+            if !ok {
+                t.Error("missing key 'param' in context")
+            }
 
-			if headCanUseGet && method == "GET" && v == "HEAD" {
-				return
-			}
+            if headCanUseGet && method == "GET" && v == "HEAD" {
+                return
+            }
 
-			if v != method {
-				t.Errorf("invalid key 'param' in context; expected '%s' but got '%s'", method, v)
-			}
-		}
-	}
+            if v != method {
+                t.Errorf("invalid key 'param' in context; expected '%s' but got '%s'", method, v)
+            }
+        }
+    }
 
-	router := New()
-	router.HeadCanUseGet = headCanUseGet
+    router := New()
+    router.HeadCanUseGet = headCanUseGet
 
-	cg := router.UsingContext().NewContextGroup("/base").NewContextGroup("/user")
-	cg.GET("/:param", makeHandler("GET"))
-	cg.POST("/:param", makeHandler("POST"))
-	cg.PATCH("/:param", makeHandler("PATCH"))
-	cg.PUT("/:param", makeHandler("PUT"))
-	cg.DELETE("/:param", makeHandler("DELETE"))
+    cg := router.UsingContext().NewContextGroup("/base").NewContextGroup("/user")
+    cg.GET("/:param", makeHandler("GET"))
+    cg.POST("/:param", makeHandler("POST"))
+    cg.PATCH("/:param", makeHandler("PATCH"))
+    cg.PUT("/:param", makeHandler("PUT"))
+    cg.DELETE("/:param", makeHandler("DELETE"))
 
-	testMethod := func(method, expect string) {
-		result = ""
-		w := httptest.NewRecorder()
-		r, _ := reqGen(method, "/base/user/"+method, nil)
-		router.ServeHTTP(w, r)
-		if expect == "" && w.Code != http.StatusMethodNotAllowed {
-			t.Errorf("Method %s not expected to match but saw code %d", method, w.Code)
-		}
+    testMethod := func(method, expect string) {
+        result = ""
+        w := httptest.NewRecorder()
+        r, _ := reqGen(method, "/base/user/" + method, nil)
+        router.ServeHTTP(w, r)
+        if expect == "" && w.Code != http.StatusMethodNotAllowed {
+            t.Errorf("Method %s not expected to match but saw code %d", method, w.Code)
+        }
 
-		if result != expect {
-			t.Errorf("Method %s got result %s", method, result)
-		}
-	}
+        if result != expect {
+            t.Errorf("Method %s got result %s", method, result)
+        }
+    }
 
-	testMethod("GET", "GET")
-	testMethod("POST", "POST")
-	testMethod("PATCH", "PATCH")
-	testMethod("PUT", "PUT")
-	testMethod("DELETE", "DELETE")
+    testMethod("GET", "GET")
+    testMethod("POST", "POST")
+    testMethod("PATCH", "PATCH")
+    testMethod("PUT", "PUT")
+    testMethod("DELETE", "DELETE")
 
-	if headCanUseGet {
-		t.Log("Test implicit HEAD with HeadCanUseGet = true")
-		testMethod("HEAD", "GET")
-	} else {
-		t.Log("Test implicit HEAD with HeadCanUseGet = false")
-		testMethod("HEAD", "")
-	}
+    if headCanUseGet {
+        t.Log("Test implicit HEAD with HeadCanUseGet = true")
+        testMethod("HEAD", "GET")
+    } else {
+        t.Log("Test implicit HEAD with HeadCanUseGet = false")
+        testMethod("HEAD", "")
+    }
 
-	cg.HEAD("/:param", makeHandler("HEAD"))
-	testMethod("HEAD", "HEAD")
+    cg.HEAD("/:param", makeHandler("HEAD"))
+    testMethod("HEAD", "HEAD")
 }
 
 func TestNewContextGroup(t *testing.T) {
-	router := New()
-	group := router.NewGroup("/api")
+    router := New()
+    group := router.NewGroup("/api")
 
-	group.GET("/v1", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		w.Write([]byte(`200 OK GET /api/v1`))
-	})
+    group.GET("/v1", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+        w.Write([]byte(`200 OK GET /api/v1`))
+    })
 
-	group.UsingContext().GET("/v2", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`200 OK GET /api/v2`))
-	})
+    group.UsingContext().GET("/v2", func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte(`200 OK GET /api/v2`))
+    })
 
-	tests := []struct {
-		uri, expected string
-	}{
-		{"/api/v1", "200 OK GET /api/v1"},
-		{"/api/v2", "200 OK GET /api/v2"},
-	}
+    tests := []struct {
+        uri, expected string
+    }{
+        {"/api/v1", "200 OK GET /api/v1"},
+        {"/api/v2", "200 OK GET /api/v2"},
+    }
 
-	for _, tc := range tests {
-		r, err := http.NewRequest("GET", tc.uri, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+    for _, tc := range tests {
+        r, err := http.NewRequest("GET", tc.uri, nil)
+        if err != nil {
+            t.Fatal(err)
+        }
 
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, r)
+        w := httptest.NewRecorder()
+        router.ServeHTTP(w, r)
 
-		if w.Code != http.StatusOK {
-			t.Errorf("GET %s: expected %d, but got %d", tc.uri, http.StatusOK, w.Code)
-		}
-		if got := w.Body.String(); got != tc.expected {
-			t.Errorf("GET %s : expected %q, but got %q", tc.uri, tc.expected, got)
-		}
+        if w.Code != http.StatusOK {
+            t.Errorf("GET %s: expected %d, but got %d", tc.uri, http.StatusOK, w.Code)
+        }
+        if got := w.Body.String(); got != tc.expected {
+            t.Errorf("GET %s : expected %q, but got %q", tc.uri, tc.expected, got)
+        }
 
-	}
+    }
 }

--- a/context_test.go
+++ b/context_test.go
@@ -3,131 +3,131 @@
 package httptreemux
 
 import (
-    "context"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestContextParams(t *testing.T) {
-    m := map[string]string{"id": "123"}
-    ctx := context.WithValue(context.Background(), ParamsContextKey, m)
+	m := map[string]string{"id": "123"}
+	ctx := context.WithValue(context.Background(), ParamsContextKey, m)
 
-    params := ContextParams(ctx)
-    if params == nil {
-        t.Errorf("expected '%#v', but got '%#v'", m, params)
-    }
+	params := ContextParams(ctx)
+	if params == nil {
+		t.Errorf("expected '%#v', but got '%#v'", m, params)
+	}
 
-    if v := params["id"]; v != "123" {
-        t.Errorf("expected '%s', but got '%#v'", m["id"], params["id"])
-    }
+	if v := params["id"]; v != "123" {
+		t.Errorf("expected '%s', but got '%#v'", m["id"], params["id"])
+	}
 }
 
 func TestContextGroupMethods(t *testing.T) {
-    for _, scenario := range scenarios {
-        t.Log(scenario.description)
-        testContextGroupMethods(t, scenario.RequestCreator, true)
-        testContextGroupMethods(t, scenario.RequestCreator, false)
-    }
+	for _, scenario := range scenarios {
+		t.Log(scenario.description)
+		testContextGroupMethods(t, scenario.RequestCreator, true)
+		testContextGroupMethods(t, scenario.RequestCreator, false)
+	}
 }
 
 func testContextGroupMethods(t *testing.T, reqGen RequestCreator, headCanUseGet bool) {
-    var result string
-    makeHandler := func(method string) http.HandlerFunc {
-        return func(w http.ResponseWriter, r *http.Request) {
-            result = method
+	var result string
+	makeHandler := func(method string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			result = method
 
-            v, ok := ContextParams(r.Context())["param"]
-            if !ok {
-                t.Error("missing key 'param' in context")
-            }
+			v, ok := ContextParams(r.Context())["param"]
+			if !ok {
+				t.Error("missing key 'param' in context")
+			}
 
-            if headCanUseGet && method == "GET" && v == "HEAD" {
-                return
-            }
+			if headCanUseGet && method == "GET" && v == "HEAD" {
+				return
+			}
 
-            if v != method {
-                t.Errorf("invalid key 'param' in context; expected '%s' but got '%s'", method, v)
-            }
-        }
-    }
+			if v != method {
+				t.Errorf("invalid key 'param' in context; expected '%s' but got '%s'", method, v)
+			}
+		}
+	}
 
-    router := New()
-    router.HeadCanUseGet = headCanUseGet
+	router := New()
+	router.HeadCanUseGet = headCanUseGet
 
-    cg := router.UsingContext().NewContextGroup("/base").NewContextGroup("/user")
-    cg.GET("/:param", makeHandler("GET"))
-    cg.POST("/:param", makeHandler("POST"))
-    cg.PATCH("/:param", makeHandler("PATCH"))
-    cg.PUT("/:param", makeHandler("PUT"))
-    cg.DELETE("/:param", makeHandler("DELETE"))
+	cg := router.UsingContext().NewContextGroup("/base").NewContextGroup("/user")
+	cg.GET("/:param", makeHandler("GET"))
+	cg.POST("/:param", makeHandler("POST"))
+	cg.PATCH("/:param", makeHandler("PATCH"))
+	cg.PUT("/:param", makeHandler("PUT"))
+	cg.DELETE("/:param", makeHandler("DELETE"))
 
-    testMethod := func(method, expect string) {
-        result = ""
-        w := httptest.NewRecorder()
-        r, _ := reqGen(method, "/base/user/" + method, nil)
-        router.ServeHTTP(w, r)
-        if expect == "" && w.Code != http.StatusMethodNotAllowed {
-            t.Errorf("Method %s not expected to match but saw code %d", method, w.Code)
-        }
+	testMethod := func(method, expect string) {
+		result = ""
+		w := httptest.NewRecorder()
+		r, _ := reqGen(method, "/base/user/"+method, nil)
+		router.ServeHTTP(w, r)
+		if expect == "" && w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("Method %s not expected to match but saw code %d", method, w.Code)
+		}
 
-        if result != expect {
-            t.Errorf("Method %s got result %s", method, result)
-        }
-    }
+		if result != expect {
+			t.Errorf("Method %s got result %s", method, result)
+		}
+	}
 
-    testMethod("GET", "GET")
-    testMethod("POST", "POST")
-    testMethod("PATCH", "PATCH")
-    testMethod("PUT", "PUT")
-    testMethod("DELETE", "DELETE")
+	testMethod("GET", "GET")
+	testMethod("POST", "POST")
+	testMethod("PATCH", "PATCH")
+	testMethod("PUT", "PUT")
+	testMethod("DELETE", "DELETE")
 
-    if headCanUseGet {
-        t.Log("Test implicit HEAD with HeadCanUseGet = true")
-        testMethod("HEAD", "GET")
-    } else {
-        t.Log("Test implicit HEAD with HeadCanUseGet = false")
-        testMethod("HEAD", "")
-    }
+	if headCanUseGet {
+		t.Log("Test implicit HEAD with HeadCanUseGet = true")
+		testMethod("HEAD", "GET")
+	} else {
+		t.Log("Test implicit HEAD with HeadCanUseGet = false")
+		testMethod("HEAD", "")
+	}
 
-    cg.HEAD("/:param", makeHandler("HEAD"))
-    testMethod("HEAD", "HEAD")
+	cg.HEAD("/:param", makeHandler("HEAD"))
+	testMethod("HEAD", "HEAD")
 }
 
 func TestNewContextGroup(t *testing.T) {
-    router := New()
-    group := router.NewGroup("/api")
+	router := New()
+	group := router.NewGroup("/api")
 
-    group.GET("/v1", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-        w.Write([]byte(`200 OK GET /api/v1`))
-    })
+	group.GET("/v1", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		w.Write([]byte(`200 OK GET /api/v1`))
+	})
 
-    group.UsingContext().GET("/v2", func(w http.ResponseWriter, r *http.Request) {
-        w.Write([]byte(`200 OK GET /api/v2`))
-    })
+	group.UsingContext().GET("/v2", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`200 OK GET /api/v2`))
+	})
 
-    tests := []struct {
-        uri, expected string
-    }{
-        {"/api/v1", "200 OK GET /api/v1"},
-        {"/api/v2", "200 OK GET /api/v2"},
-    }
+	tests := []struct {
+		uri, expected string
+	}{
+		{"/api/v1", "200 OK GET /api/v1"},
+		{"/api/v2", "200 OK GET /api/v2"},
+	}
 
-    for _, tc := range tests {
-        r, err := http.NewRequest("GET", tc.uri, nil)
-        if err != nil {
-            t.Fatal(err)
-        }
+	for _, tc := range tests {
+		r, err := http.NewRequest("GET", tc.uri, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-        w := httptest.NewRecorder()
-        router.ServeHTTP(w, r)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
 
-        if w.Code != http.StatusOK {
-            t.Errorf("GET %s: expected %d, but got %d", tc.uri, http.StatusOK, w.Code)
-        }
-        if got := w.Body.String(); got != tc.expected {
-            t.Errorf("GET %s : expected %q, but got %q", tc.uri, tc.expected, got)
-        }
+		if w.Code != http.StatusOK {
+			t.Errorf("GET %s: expected %d, but got %d", tc.uri, http.StatusOK, w.Code)
+		}
+		if got := w.Body.String(); got != tc.expected {
+			t.Errorf("GET %s : expected %q, but got %q", tc.uri, tc.expected, got)
+		}
 
-    }
+	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -53,15 +53,15 @@ func testHandleWithContext(t *testing.T, reqGen RequestCreator, headCanUseGet bo
 		}
 	}
 
-	router := New()
-	router.HeadCanUseGet = headCanUseGet
+	router := New().UsingContext()
+	router.TreeMux().HeadCanUseGet = headCanUseGet
 
-	g := router.NewGroup("/base").NewGroup("/user")
-	g.HandleWithContext("GET", "/:param", makeHandler("GET"))
-	g.HandleWithContext("POST", "/:param", makeHandler("POST"))
-	g.HandleWithContext("PATCH", "/:param", makeHandler("PATCH"))
-	g.HandleWithContext("PUT", "/:param", makeHandler("PUT"))
-	g.HandleWithContext("DELETE", "/:param", makeHandler("DELETE"))
+	cg := router.NewContextGroup("/base").NewContextGroup("/user")
+	cg.GET("/:param", makeHandler("GET"))
+	cg.POST("/:param", makeHandler("POST"))
+	cg.PATCH("/:param", makeHandler("PATCH"))
+	cg.PUT("/:param", makeHandler("PUT"))
+	cg.DELETE("/:param", makeHandler("DELETE"))
 
 	testMethod := func(method, expect string) {
 		result = ""
@@ -91,6 +91,6 @@ func testHandleWithContext(t *testing.T, reqGen RequestCreator, headCanUseGet bo
 		testMethod("HEAD", "")
 	}
 
-	router.HandleWithContext("HEAD", "/base/user/:param", makeHandler("HEAD"))
+	router.Handle("HEAD", "/base/user/:param", makeHandler("HEAD"))
 	testMethod("HEAD", "HEAD")
 }

--- a/router.go
+++ b/router.go
@@ -5,11 +5,11 @@
 package httptreemux
 
 import (
-    "fmt"
-    "net/http"
-    "net/url"
+	"fmt"
+	"net/http"
+	"net/url"
 
-    "github.com/dimfeld/httppath"
+	"github.com/dimfeld/httppath"
 )
 
 // The params argument contains the parameters parsed from wildcards and catch-alls in the URL.
@@ -38,246 +38,246 @@ type RedirectBehavior int
 type PathSource int
 
 const (
-    Redirect301 RedirectBehavior = iota // Return 301 Moved Permanently
-    Redirect307                         // Return 307 HTTP/1.1 Temporary Redirect
-    Redirect308                         // Return a 308 RFC7538 Permanent Redirect
-    UseHandler                          // Just call the handler function
+	Redirect301 RedirectBehavior = iota // Return 301 Moved Permanently
+	Redirect307                         // Return 307 HTTP/1.1 Temporary Redirect
+	Redirect308                         // Return a 308 RFC7538 Permanent Redirect
+	UseHandler                          // Just call the handler function
 
-    RequestURI PathSource = iota // Use r.RequestURI
-    URLPath                      // Use r.URL.Path
+	RequestURI PathSource = iota // Use r.RequestURI
+	URLPath                      // Use r.URL.Path
 )
 
 type TreeMux struct {
-    root                        *node
+	root *node
 
-    Group
+	Group
 
-    // The default PanicHandler just returns a 500 code.
-    PanicHandler                PanicHandler
+	// The default PanicHandler just returns a 500 code.
+	PanicHandler PanicHandler
 
-    // The default NotFoundHandler is http.NotFound.
-    NotFoundHandler             func(w http.ResponseWriter, r *http.Request)
+	// The default NotFoundHandler is http.NotFound.
+	NotFoundHandler func(w http.ResponseWriter, r *http.Request)
 
-    // Any OPTIONS request that matches a path without its own OPTIONS handler will use this handler,
-    // if set, instead of calling MethodNotAllowedHandler.
-    OptionsHandler              HandlerFunc
+	// Any OPTIONS request that matches a path without its own OPTIONS handler will use this handler,
+	// if set, instead of calling MethodNotAllowedHandler.
+	OptionsHandler HandlerFunc
 
-    // MethodNotAllowedHandler is called when a pattern matches, but that
-    // pattern does not have a handler for the requested method. The default
-    // handler just writes the status code http.StatusMethodNotAllowed and adds
-    // the required Allowed header.
-    // The methods parameter contains the map of each method to the corresponding
-    // handler function.
-    MethodNotAllowedHandler     func(w http.ResponseWriter, r *http.Request,
-    methods map[string]HandlerFunc)
+	// MethodNotAllowedHandler is called when a pattern matches, but that
+	// pattern does not have a handler for the requested method. The default
+	// handler just writes the status code http.StatusMethodNotAllowed and adds
+	// the required Allowed header.
+	// The methods parameter contains the map of each method to the corresponding
+	// handler function.
+	MethodNotAllowedHandler func(w http.ResponseWriter, r *http.Request,
+		methods map[string]HandlerFunc)
 
-    // HeadCanUseGet allows the router to use the GET handler to respond to
-    // HEAD requests if no explicit HEAD handler has been added for the
-    // matching pattern. This is true by default.
-    HeadCanUseGet               bool
+	// HeadCanUseGet allows the router to use the GET handler to respond to
+	// HEAD requests if no explicit HEAD handler has been added for the
+	// matching pattern. This is true by default.
+	HeadCanUseGet bool
 
-    // RedirectCleanPath allows the router to try clean the current request path,
-    // if no handler is registered for it, using CleanPath from github.com/dimfeld/httppath.
-    // This is true by default.
-    RedirectCleanPath           bool
+	// RedirectCleanPath allows the router to try clean the current request path,
+	// if no handler is registered for it, using CleanPath from github.com/dimfeld/httppath.
+	// This is true by default.
+	RedirectCleanPath bool
 
-    // RedirectTrailingSlash enables automatic redirection in case router doesn't find a matching route
-    // for the current request path but a handler for the path with or without the trailing
-    // slash exists. This is true by default.
-    RedirectTrailingSlash       bool
+	// RedirectTrailingSlash enables automatic redirection in case router doesn't find a matching route
+	// for the current request path but a handler for the path with or without the trailing
+	// slash exists. This is true by default.
+	RedirectTrailingSlash bool
 
-    // RemoveCatchAllTrailingSlash removes the trailing slash when a catch-all pattern
-    // is matched, if set to true. By default, catch-all paths are never redirected.
-    RemoveCatchAllTrailingSlash bool
+	// RemoveCatchAllTrailingSlash removes the trailing slash when a catch-all pattern
+	// is matched, if set to true. By default, catch-all paths are never redirected.
+	RemoveCatchAllTrailingSlash bool
 
-    // RedirectBehavior sets the default redirect behavior when RedirectTrailingSlash or
-    // RedirectCleanPath are true. The default value is Redirect301.
-    RedirectBehavior            RedirectBehavior
+	// RedirectBehavior sets the default redirect behavior when RedirectTrailingSlash or
+	// RedirectCleanPath are true. The default value is Redirect301.
+	RedirectBehavior RedirectBehavior
 
-    // RedirectMethodBehavior overrides the default behavior for a particular HTTP method.
-    // The key is the method name, and the value is the behavior to use for that method.
-    RedirectMethodBehavior      map[string]RedirectBehavior
+	// RedirectMethodBehavior overrides the default behavior for a particular HTTP method.
+	// The key is the method name, and the value is the behavior to use for that method.
+	RedirectMethodBehavior map[string]RedirectBehavior
 
-    // PathSource determines from where the router gets its path to search.
-    // By default it pulls the data from the RequestURI member, but this can
-    // be overridden to use URL.Path instead.
-    //
-    // There is a small tradeoff here. Using RequestURI allows the router to handle
-    // encoded slashes (i.e. %2f) in the URL properly, while URL.Path provides
-    // better compatibility with some utility functions in the http
-    // library that modify the Request before passing it to the router.
-    PathSource                  PathSource
+	// PathSource determines from where the router gets its path to search.
+	// By default it pulls the data from the RequestURI member, but this can
+	// be overridden to use URL.Path instead.
+	//
+	// There is a small tradeoff here. Using RequestURI allows the router to handle
+	// encoded slashes (i.e. %2f) in the URL properly, while URL.Path provides
+	// better compatibility with some utility functions in the http
+	// library that modify the Request before passing it to the router.
+	PathSource PathSource
 
-    // EscapeAddedRoutes controls URI escaping behavior when adding a route to the tree.
-    // If set to true, the router will add both the route as originally passed, and
-    // a version passed through URL.EscapedPath. This behavior is disabled by default.
-    EscapeAddedRoutes           bool
+	// EscapeAddedRoutes controls URI escaping behavior when adding a route to the tree.
+	// If set to true, the router will add both the route as originally passed, and
+	// a version passed through URL.EscapedPath. This behavior is disabled by default.
+	EscapeAddedRoutes bool
 }
 
 // Dump returns a text representation of the routing tree.
 func (t *TreeMux) Dump() string {
-    return t.root.dumpTree("", "")
+	return t.root.dumpTree("", "")
 }
 
 func (t *TreeMux) serveHTTPPanic(w http.ResponseWriter, r *http.Request) {
-    if err := recover(); err != nil {
-        t.PanicHandler(w, r, err)
-    }
+	if err := recover(); err != nil {
+		t.PanicHandler(w, r, err)
+	}
 }
 
 func (t *TreeMux) redirectStatusCode(method string) (int, bool) {
-    var behavior RedirectBehavior
-    var ok bool
-    if behavior, ok = t.RedirectMethodBehavior[method]; !ok {
-        behavior = t.RedirectBehavior
-    }
-    switch behavior {
-    case Redirect301:
-        return http.StatusMovedPermanently, true
-    case Redirect307:
-        return http.StatusTemporaryRedirect, true
-    case Redirect308:
-        // Go doesn't have a constant for this yet. Yet another sign
-        // that you probably shouldn't use it.
-        return 308, true
-    case UseHandler:
-        return 0, false
-    default:
-        return http.StatusMovedPermanently, true
-    }
+	var behavior RedirectBehavior
+	var ok bool
+	if behavior, ok = t.RedirectMethodBehavior[method]; !ok {
+		behavior = t.RedirectBehavior
+	}
+	switch behavior {
+	case Redirect301:
+		return http.StatusMovedPermanently, true
+	case Redirect307:
+		return http.StatusTemporaryRedirect, true
+	case Redirect308:
+		// Go doesn't have a constant for this yet. Yet another sign
+		// that you probably shouldn't use it.
+		return 308, true
+	case UseHandler:
+		return 0, false
+	default:
+		return http.StatusMovedPermanently, true
+	}
 }
 
 func redirect(w http.ResponseWriter, r *http.Request, newPath string, statusCode int) {
-    newURL := url.URL{
-        Path:     newPath,
-        RawQuery: r.URL.RawQuery,
-        Fragment: r.URL.Fragment,
-    }
-    http.Redirect(w, r, newURL.String(), statusCode)
+	newURL := url.URL{
+		Path:     newPath,
+		RawQuery: r.URL.RawQuery,
+		Fragment: r.URL.Fragment,
+	}
+	http.Redirect(w, r, newURL.String(), statusCode)
 }
 
 func (t *TreeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-    if t.PanicHandler != nil {
-        defer t.serveHTTPPanic(w, r)
-    }
+	if t.PanicHandler != nil {
+		defer t.serveHTTPPanic(w, r)
+	}
 
-    path := r.RequestURI
-    pathLen := len(path)
-    if pathLen > 0 && t.PathSource == RequestURI {
-        rawQueryLen := len(r.URL.RawQuery)
+	path := r.RequestURI
+	pathLen := len(path)
+	if pathLen > 0 && t.PathSource == RequestURI {
+		rawQueryLen := len(r.URL.RawQuery)
 
-        if rawQueryLen != 0 || path[pathLen - 1] == '?' {
-            // Remove any query string and the ?.
-            path = path[:pathLen - rawQueryLen - 1]
-            pathLen = len(path)
-        }
-    } else {
-        // In testing with http.NewRequest,
-        // RequestURI is not set so just grab URL.Path instead.
-        path = r.URL.Path
-        pathLen = len(path)
-    }
+		if rawQueryLen != 0 || path[pathLen-1] == '?' {
+			// Remove any query string and the ?.
+			path = path[:pathLen-rawQueryLen-1]
+			pathLen = len(path)
+		}
+	} else {
+		// In testing with http.NewRequest,
+		// RequestURI is not set so just grab URL.Path instead.
+		path = r.URL.Path
+		pathLen = len(path)
+	}
 
-    trailingSlash := path[pathLen - 1] == '/' && pathLen > 1
-    if trailingSlash && t.RedirectTrailingSlash {
-        path = path[:pathLen - 1]
-    }
-    n, handler, params := t.root.search(r.Method, path[1:])
-    if n == nil {
-        if t.RedirectCleanPath {
-            // Path was not found. Try cleaning it up and search again.
-            // TODO Test this
-            cleanPath := httppath.Clean(path)
-            n, handler, params = t.root.search(r.Method, cleanPath[1:])
-            if n == nil {
-                // Still nothing found.
-                t.NotFoundHandler(w, r)
-                return
-            } else {
-                if statusCode, ok := t.redirectStatusCode(r.Method); ok {
-                    // Redirect to the actual path
-                    redirect(w, r, cleanPath, statusCode)
-                    return
-                }
-            }
-        } else {
-            t.NotFoundHandler(w, r)
-            return
-        }
-    }
+	trailingSlash := path[pathLen-1] == '/' && pathLen > 1
+	if trailingSlash && t.RedirectTrailingSlash {
+		path = path[:pathLen-1]
+	}
+	n, handler, params := t.root.search(r.Method, path[1:])
+	if n == nil {
+		if t.RedirectCleanPath {
+			// Path was not found. Try cleaning it up and search again.
+			// TODO Test this
+			cleanPath := httppath.Clean(path)
+			n, handler, params = t.root.search(r.Method, cleanPath[1:])
+			if n == nil {
+				// Still nothing found.
+				t.NotFoundHandler(w, r)
+				return
+			} else {
+				if statusCode, ok := t.redirectStatusCode(r.Method); ok {
+					// Redirect to the actual path
+					redirect(w, r, cleanPath, statusCode)
+					return
+				}
+			}
+		} else {
+			t.NotFoundHandler(w, r)
+			return
+		}
+	}
 
-    if handler == nil {
-        if r.Method == "OPTIONS" && t.OptionsHandler != nil {
-            handler = t.OptionsHandler
-        }
+	if handler == nil {
+		if r.Method == "OPTIONS" && t.OptionsHandler != nil {
+			handler = t.OptionsHandler
+		}
 
-        if handler == nil {
-            t.MethodNotAllowedHandler(w, r, n.leafHandler)
-            return
-        }
-    }
+		if handler == nil {
+			t.MethodNotAllowedHandler(w, r, n.leafHandler)
+			return
+		}
+	}
 
-    if !n.isCatchAll || t.RemoveCatchAllTrailingSlash {
-        if trailingSlash != n.addSlash && t.RedirectTrailingSlash {
-            if statusCode, ok := t.redirectStatusCode(r.Method); ok {
-                if n.addSlash {
-                    // Need to add a slash.
-                    redirect(w, r, path + "/", statusCode)
-                } else if path != "/" {
-                    // We need to remove the slash. This was already done at the
-                    // beginning of the function.
-                    redirect(w, r, path, statusCode)
-                }
-                return
-            }
-        }
-    }
+	if !n.isCatchAll || t.RemoveCatchAllTrailingSlash {
+		if trailingSlash != n.addSlash && t.RedirectTrailingSlash {
+			if statusCode, ok := t.redirectStatusCode(r.Method); ok {
+				if n.addSlash {
+					// Need to add a slash.
+					redirect(w, r, path+"/", statusCode)
+				} else if path != "/" {
+					// We need to remove the slash. This was already done at the
+					// beginning of the function.
+					redirect(w, r, path, statusCode)
+				}
+				return
+			}
+		}
+	}
 
-    var paramMap map[string]string
-    if len(params) != 0 {
-        if len(params) != len(n.leafWildcardNames) {
-            // Need better behavior here. Should this be a panic?
-            panic(fmt.Sprintf("httptreemux parameter list length mismatch: %v, %v",
-                params, n.leafWildcardNames))
-        }
+	var paramMap map[string]string
+	if len(params) != 0 {
+		if len(params) != len(n.leafWildcardNames) {
+			// Need better behavior here. Should this be a panic?
+			panic(fmt.Sprintf("httptreemux parameter list length mismatch: %v, %v",
+				params, n.leafWildcardNames))
+		}
 
-        paramMap = make(map[string]string)
-        numParams := len(params)
-        for index := 0; index < numParams; index++ {
-            paramMap[n.leafWildcardNames[numParams - index - 1]] = params[index]
-        }
-    }
+		paramMap = make(map[string]string)
+		numParams := len(params)
+		for index := 0; index < numParams; index++ {
+			paramMap[n.leafWildcardNames[numParams-index-1]] = params[index]
+		}
+	}
 
-    handler(w, r, paramMap)
+	handler(w, r, paramMap)
 }
 
 // MethodNotAllowedHandler is the default handler for TreeMux.MethodNotAllowedHandler,
 // which is called for patterns that match, but do not have a handler installed for the
 // requested method. It simply writes the status code http.StatusMethodNotAllowed.
 func MethodNotAllowedHandler(w http.ResponseWriter, r *http.Request,
-methods map[string]HandlerFunc) {
+	methods map[string]HandlerFunc) {
 
-    for m := range methods {
-        w.Header().Add("Allow", m)
-    }
+	for m := range methods {
+		w.Header().Add("Allow", m)
+	}
 
-    w.WriteHeader(http.StatusMethodNotAllowed)
+	w.WriteHeader(http.StatusMethodNotAllowed)
 }
 
 func New() *TreeMux {
-    tm := &TreeMux{
-        root:                    &node{path: "/"},
-        NotFoundHandler:         http.NotFound,
-        MethodNotAllowedHandler: MethodNotAllowedHandler,
-        HeadCanUseGet:           true,
-        RedirectTrailingSlash:   true,
-        RedirectCleanPath:       true,
-        RedirectBehavior:        Redirect301,
-        RedirectMethodBehavior:  make(map[string]RedirectBehavior),
-        PathSource:              RequestURI,
-        EscapeAddedRoutes:       false,
-    }
-    tm.Group.mux = tm
-    return tm
+	tm := &TreeMux{
+		root:                    &node{path: "/"},
+		NotFoundHandler:         http.NotFound,
+		MethodNotAllowedHandler: MethodNotAllowedHandler,
+		HeadCanUseGet:           true,
+		RedirectTrailingSlash:   true,
+		RedirectCleanPath:       true,
+		RedirectBehavior:        Redirect301,
+		RedirectMethodBehavior:  make(map[string]RedirectBehavior),
+		PathSource:              RequestURI,
+		EscapeAddedRoutes:       false,
+	}
+	tm.Group.mux = tm
+	return tm
 }

--- a/router.go
+++ b/router.go
@@ -5,11 +5,11 @@
 package httptreemux
 
 import (
-	"fmt"
-	"net/http"
-	"net/url"
+    "fmt"
+    "net/http"
+    "net/url"
 
-	"github.com/dimfeld/httppath"
+    "github.com/dimfeld/httppath"
 )
 
 // The params argument contains the parameters parsed from wildcards and catch-alls in the URL.
@@ -38,250 +38,246 @@ type RedirectBehavior int
 type PathSource int
 
 const (
-	Redirect301 RedirectBehavior = iota // Return 301 Moved Permanently
-	Redirect307                         // Return 307 HTTP/1.1 Temporary Redirect
-	Redirect308                         // Return a 308 RFC7538 Permanent Redirect
-	UseHandler                          // Just call the handler function
+    Redirect301 RedirectBehavior = iota // Return 301 Moved Permanently
+    Redirect307                         // Return 307 HTTP/1.1 Temporary Redirect
+    Redirect308                         // Return a 308 RFC7538 Permanent Redirect
+    UseHandler                          // Just call the handler function
 
-	RequestURI PathSource = iota // Use r.RequestURI
-	URLPath                      // Use r.URL.Path
+    RequestURI PathSource = iota // Use r.RequestURI
+    URLPath                      // Use r.URL.Path
 )
 
-type CGroup struct {
-	*Group
-}
-
 type TreeMux struct {
-	root *node
+    root                        *node
 
-	Group
+    Group
 
-	// The default PanicHandler just returns a 500 code.
-	PanicHandler PanicHandler
+    // The default PanicHandler just returns a 500 code.
+    PanicHandler                PanicHandler
 
-	// The default NotFoundHandler is http.NotFound.
-	NotFoundHandler func(w http.ResponseWriter, r *http.Request)
+    // The default NotFoundHandler is http.NotFound.
+    NotFoundHandler             func(w http.ResponseWriter, r *http.Request)
 
-	// Any OPTIONS request that matches a path without its own OPTIONS handler will use this handler,
-	// if set, instead of calling MethodNotAllowedHandler.
-	OptionsHandler HandlerFunc
+    // Any OPTIONS request that matches a path without its own OPTIONS handler will use this handler,
+    // if set, instead of calling MethodNotAllowedHandler.
+    OptionsHandler              HandlerFunc
 
-	// MethodNotAllowedHandler is called when a pattern matches, but that
-	// pattern does not have a handler for the requested method. The default
-	// handler just writes the status code http.StatusMethodNotAllowed and adds
-	// the required Allowed header.
-	// The methods parameter contains the map of each method to the corresponding
-	// handler function.
-	MethodNotAllowedHandler func(w http.ResponseWriter, r *http.Request,
-		methods map[string]HandlerFunc)
+    // MethodNotAllowedHandler is called when a pattern matches, but that
+    // pattern does not have a handler for the requested method. The default
+    // handler just writes the status code http.StatusMethodNotAllowed and adds
+    // the required Allowed header.
+    // The methods parameter contains the map of each method to the corresponding
+    // handler function.
+    MethodNotAllowedHandler     func(w http.ResponseWriter, r *http.Request,
+    methods map[string]HandlerFunc)
 
-	// HeadCanUseGet allows the router to use the GET handler to respond to
-	// HEAD requests if no explicit HEAD handler has been added for the
-	// matching pattern. This is true by default.
-	HeadCanUseGet bool
+    // HeadCanUseGet allows the router to use the GET handler to respond to
+    // HEAD requests if no explicit HEAD handler has been added for the
+    // matching pattern. This is true by default.
+    HeadCanUseGet               bool
 
-	// RedirectCleanPath allows the router to try clean the current request path,
-	// if no handler is registered for it, using CleanPath from github.com/dimfeld/httppath.
-	// This is true by default.
-	RedirectCleanPath bool
+    // RedirectCleanPath allows the router to try clean the current request path,
+    // if no handler is registered for it, using CleanPath from github.com/dimfeld/httppath.
+    // This is true by default.
+    RedirectCleanPath           bool
 
-	// RedirectTrailingSlash enables automatic redirection in case router doesn't find a matching route
-	// for the current request path but a handler for the path with or without the trailing
-	// slash exists. This is true by default.
-	RedirectTrailingSlash bool
+    // RedirectTrailingSlash enables automatic redirection in case router doesn't find a matching route
+    // for the current request path but a handler for the path with or without the trailing
+    // slash exists. This is true by default.
+    RedirectTrailingSlash       bool
 
-	// RemoveCatchAllTrailingSlash removes the trailing slash when a catch-all pattern
-	// is matched, if set to true. By default, catch-all paths are never redirected.
-	RemoveCatchAllTrailingSlash bool
+    // RemoveCatchAllTrailingSlash removes the trailing slash when a catch-all pattern
+    // is matched, if set to true. By default, catch-all paths are never redirected.
+    RemoveCatchAllTrailingSlash bool
 
-	// RedirectBehavior sets the default redirect behavior when RedirectTrailingSlash or
-	// RedirectCleanPath are true. The default value is Redirect301.
-	RedirectBehavior RedirectBehavior
+    // RedirectBehavior sets the default redirect behavior when RedirectTrailingSlash or
+    // RedirectCleanPath are true. The default value is Redirect301.
+    RedirectBehavior            RedirectBehavior
 
-	// RedirectMethodBehavior overrides the default behavior for a particular HTTP method.
-	// The key is the method name, and the value is the behavior to use for that method.
-	RedirectMethodBehavior map[string]RedirectBehavior
+    // RedirectMethodBehavior overrides the default behavior for a particular HTTP method.
+    // The key is the method name, and the value is the behavior to use for that method.
+    RedirectMethodBehavior      map[string]RedirectBehavior
 
-	// PathSource determines from where the router gets its path to search.
-	// By default it pulls the data from the RequestURI member, but this can
-	// be overridden to use URL.Path instead.
-	//
-	// There is a small tradeoff here. Using RequestURI allows the router to handle
-	// encoded slashes (i.e. %2f) in the URL properly, while URL.Path provides
-	// better compatibility with some utility functions in the http
-	// library that modify the Request before passing it to the router.
-	PathSource PathSource
+    // PathSource determines from where the router gets its path to search.
+    // By default it pulls the data from the RequestURI member, but this can
+    // be overridden to use URL.Path instead.
+    //
+    // There is a small tradeoff here. Using RequestURI allows the router to handle
+    // encoded slashes (i.e. %2f) in the URL properly, while URL.Path provides
+    // better compatibility with some utility functions in the http
+    // library that modify the Request before passing it to the router.
+    PathSource                  PathSource
 
-	// EscapeAddedRoutes controls URI escaping behavior when adding a route to the tree.
-	// If set to true, the router will add both the route as originally passed, and
-	// a version passed through URL.EscapedPath. This behavior is disabled by default.
-	EscapeAddedRoutes bool
+    // EscapeAddedRoutes controls URI escaping behavior when adding a route to the tree.
+    // If set to true, the router will add both the route as originally passed, and
+    // a version passed through URL.EscapedPath. This behavior is disabled by default.
+    EscapeAddedRoutes           bool
 }
 
 // Dump returns a text representation of the routing tree.
 func (t *TreeMux) Dump() string {
-	return t.root.dumpTree("", "")
+    return t.root.dumpTree("", "")
 }
 
 func (t *TreeMux) serveHTTPPanic(w http.ResponseWriter, r *http.Request) {
-	if err := recover(); err != nil {
-		t.PanicHandler(w, r, err)
-	}
+    if err := recover(); err != nil {
+        t.PanicHandler(w, r, err)
+    }
 }
 
 func (t *TreeMux) redirectStatusCode(method string) (int, bool) {
-	var behavior RedirectBehavior
-	var ok bool
-	if behavior, ok = t.RedirectMethodBehavior[method]; !ok {
-		behavior = t.RedirectBehavior
-	}
-	switch behavior {
-	case Redirect301:
-		return http.StatusMovedPermanently, true
-	case Redirect307:
-		return http.StatusTemporaryRedirect, true
-	case Redirect308:
-		// Go doesn't have a constant for this yet. Yet another sign
-		// that you probably shouldn't use it.
-		return 308, true
-	case UseHandler:
-		return 0, false
-	default:
-		return http.StatusMovedPermanently, true
-	}
+    var behavior RedirectBehavior
+    var ok bool
+    if behavior, ok = t.RedirectMethodBehavior[method]; !ok {
+        behavior = t.RedirectBehavior
+    }
+    switch behavior {
+    case Redirect301:
+        return http.StatusMovedPermanently, true
+    case Redirect307:
+        return http.StatusTemporaryRedirect, true
+    case Redirect308:
+        // Go doesn't have a constant for this yet. Yet another sign
+        // that you probably shouldn't use it.
+        return 308, true
+    case UseHandler:
+        return 0, false
+    default:
+        return http.StatusMovedPermanently, true
+    }
 }
 
 func redirect(w http.ResponseWriter, r *http.Request, newPath string, statusCode int) {
-	newURL := url.URL{
-		Path:     newPath,
-		RawQuery: r.URL.RawQuery,
-		Fragment: r.URL.Fragment,
-	}
-	http.Redirect(w, r, newURL.String(), statusCode)
+    newURL := url.URL{
+        Path:     newPath,
+        RawQuery: r.URL.RawQuery,
+        Fragment: r.URL.Fragment,
+    }
+    http.Redirect(w, r, newURL.String(), statusCode)
 }
 
 func (t *TreeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	if t.PanicHandler != nil {
-		defer t.serveHTTPPanic(w, r)
-	}
+    if t.PanicHandler != nil {
+        defer t.serveHTTPPanic(w, r)
+    }
 
-	path := r.RequestURI
-	pathLen := len(path)
-	if pathLen > 0 && t.PathSource == RequestURI {
-		rawQueryLen := len(r.URL.RawQuery)
+    path := r.RequestURI
+    pathLen := len(path)
+    if pathLen > 0 && t.PathSource == RequestURI {
+        rawQueryLen := len(r.URL.RawQuery)
 
-		if rawQueryLen != 0 || path[pathLen-1] == '?' {
-			// Remove any query string and the ?.
-			path = path[:pathLen-rawQueryLen-1]
-			pathLen = len(path)
-		}
-	} else {
-		// In testing with http.NewRequest,
-		// RequestURI is not set so just grab URL.Path instead.
-		path = r.URL.Path
-		pathLen = len(path)
-	}
+        if rawQueryLen != 0 || path[pathLen - 1] == '?' {
+            // Remove any query string and the ?.
+            path = path[:pathLen - rawQueryLen - 1]
+            pathLen = len(path)
+        }
+    } else {
+        // In testing with http.NewRequest,
+        // RequestURI is not set so just grab URL.Path instead.
+        path = r.URL.Path
+        pathLen = len(path)
+    }
 
-	trailingSlash := path[pathLen-1] == '/' && pathLen > 1
-	if trailingSlash && t.RedirectTrailingSlash {
-		path = path[:pathLen-1]
-	}
-	n, handler, params := t.root.search(r.Method, path[1:])
-	if n == nil {
-		if t.RedirectCleanPath {
-			// Path was not found. Try cleaning it up and search again.
-			// TODO Test this
-			cleanPath := httppath.Clean(path)
-			n, handler, params = t.root.search(r.Method, cleanPath[1:])
-			if n == nil {
-				// Still nothing found.
-				t.NotFoundHandler(w, r)
-				return
-			} else {
-				if statusCode, ok := t.redirectStatusCode(r.Method); ok {
-					// Redirect to the actual path
-					redirect(w, r, cleanPath, statusCode)
-					return
-				}
-			}
-		} else {
-			t.NotFoundHandler(w, r)
-			return
-		}
-	}
+    trailingSlash := path[pathLen - 1] == '/' && pathLen > 1
+    if trailingSlash && t.RedirectTrailingSlash {
+        path = path[:pathLen - 1]
+    }
+    n, handler, params := t.root.search(r.Method, path[1:])
+    if n == nil {
+        if t.RedirectCleanPath {
+            // Path was not found. Try cleaning it up and search again.
+            // TODO Test this
+            cleanPath := httppath.Clean(path)
+            n, handler, params = t.root.search(r.Method, cleanPath[1:])
+            if n == nil {
+                // Still nothing found.
+                t.NotFoundHandler(w, r)
+                return
+            } else {
+                if statusCode, ok := t.redirectStatusCode(r.Method); ok {
+                    // Redirect to the actual path
+                    redirect(w, r, cleanPath, statusCode)
+                    return
+                }
+            }
+        } else {
+            t.NotFoundHandler(w, r)
+            return
+        }
+    }
 
-	if handler == nil {
-		if r.Method == "OPTIONS" && t.OptionsHandler != nil {
-			handler = t.OptionsHandler
-		}
+    if handler == nil {
+        if r.Method == "OPTIONS" && t.OptionsHandler != nil {
+            handler = t.OptionsHandler
+        }
 
-		if handler == nil {
-			t.MethodNotAllowedHandler(w, r, n.leafHandler)
-			return
-		}
-	}
+        if handler == nil {
+            t.MethodNotAllowedHandler(w, r, n.leafHandler)
+            return
+        }
+    }
 
-	if !n.isCatchAll || t.RemoveCatchAllTrailingSlash {
-		if trailingSlash != n.addSlash && t.RedirectTrailingSlash {
-			if statusCode, ok := t.redirectStatusCode(r.Method); ok {
-				if n.addSlash {
-					// Need to add a slash.
-					redirect(w, r, path+"/", statusCode)
-				} else if path != "/" {
-					// We need to remove the slash. This was already done at the
-					// beginning of the function.
-					redirect(w, r, path, statusCode)
-				}
-				return
-			}
-		}
-	}
+    if !n.isCatchAll || t.RemoveCatchAllTrailingSlash {
+        if trailingSlash != n.addSlash && t.RedirectTrailingSlash {
+            if statusCode, ok := t.redirectStatusCode(r.Method); ok {
+                if n.addSlash {
+                    // Need to add a slash.
+                    redirect(w, r, path + "/", statusCode)
+                } else if path != "/" {
+                    // We need to remove the slash. This was already done at the
+                    // beginning of the function.
+                    redirect(w, r, path, statusCode)
+                }
+                return
+            }
+        }
+    }
 
-	var paramMap map[string]string
-	if len(params) != 0 {
-		if len(params) != len(n.leafWildcardNames) {
-			// Need better behavior here. Should this be a panic?
-			panic(fmt.Sprintf("httptreemux parameter list length mismatch: %v, %v",
-				params, n.leafWildcardNames))
-		}
+    var paramMap map[string]string
+    if len(params) != 0 {
+        if len(params) != len(n.leafWildcardNames) {
+            // Need better behavior here. Should this be a panic?
+            panic(fmt.Sprintf("httptreemux parameter list length mismatch: %v, %v",
+                params, n.leafWildcardNames))
+        }
 
-		paramMap = make(map[string]string)
-		numParams := len(params)
-		for index := 0; index < numParams; index++ {
-			paramMap[n.leafWildcardNames[numParams-index-1]] = params[index]
-		}
-	}
+        paramMap = make(map[string]string)
+        numParams := len(params)
+        for index := 0; index < numParams; index++ {
+            paramMap[n.leafWildcardNames[numParams - index - 1]] = params[index]
+        }
+    }
 
-	handler(w, r, paramMap)
+    handler(w, r, paramMap)
 }
 
 // MethodNotAllowedHandler is the default handler for TreeMux.MethodNotAllowedHandler,
 // which is called for patterns that match, but do not have a handler installed for the
 // requested method. It simply writes the status code http.StatusMethodNotAllowed.
 func MethodNotAllowedHandler(w http.ResponseWriter, r *http.Request,
-	methods map[string]HandlerFunc) {
+methods map[string]HandlerFunc) {
 
-	for m := range methods {
-		w.Header().Add("Allow", m)
-	}
+    for m := range methods {
+        w.Header().Add("Allow", m)
+    }
 
-	w.WriteHeader(http.StatusMethodNotAllowed)
+    w.WriteHeader(http.StatusMethodNotAllowed)
 }
 
 func New() *TreeMux {
-	tm := &TreeMux{
-		root:                    &node{path: "/"},
-		NotFoundHandler:         http.NotFound,
-		MethodNotAllowedHandler: MethodNotAllowedHandler,
-		HeadCanUseGet:           true,
-		RedirectTrailingSlash:   true,
-		RedirectCleanPath:       true,
-		RedirectBehavior:        Redirect301,
-		RedirectMethodBehavior:  make(map[string]RedirectBehavior),
-		PathSource:              RequestURI,
-		EscapeAddedRoutes:       false,
-	}
-	tm.Group.mux = tm
-	return tm
+    tm := &TreeMux{
+        root:                    &node{path: "/"},
+        NotFoundHandler:         http.NotFound,
+        MethodNotAllowedHandler: MethodNotAllowedHandler,
+        HeadCanUseGet:           true,
+        RedirectTrailingSlash:   true,
+        RedirectCleanPath:       true,
+        RedirectBehavior:        Redirect301,
+        RedirectMethodBehavior:  make(map[string]RedirectBehavior),
+        PathSource:              RequestURI,
+        EscapeAddedRoutes:       false,
+    }
+    tm.Group.mux = tm
+    return tm
 }

--- a/router.go
+++ b/router.go
@@ -47,6 +47,10 @@ const (
 	URLPath                      // Use r.URL.Path
 )
 
+type CGroup struct {
+	*Group
+}
+
 type TreeMux struct {
 	root *node
 


### PR DESCRIPTION
In reference to Issue #30, I've attempted to incorporate support for `http.HandlerFunc`, via use of `context.Context`. 

**Notes:**
- All code changes are contained within two files, `context.go` and `context_test.go`, with both files requiring at least Go 1.7 in order to compile. This prevents us from breaking Go 1.6 users, and the original API.
- I chose an "adapter"-style approach, due to the constraints of our current situation:

1. We cannot break the current API
1. Any code that references the `context` package will NOT compile if being used via Go 1.6. Thus, any Go 1.7-specific code must be in its own files, with build tags.
1. By attempting to circumvent the compilation problem by using a service such as `gopkg.in`, we would be forced to maintain the `v2` API there, while the original `v1` API would still be the `master` branch of the Git repo, thus leading to an awkward work flow.
1. If we want to give full feature support for `http.HandlerFunc` (all of the syntatic-sugar methods, its own `Group`, etc.), then we basically need to duplicate the entire code base, most likely in its own sub-package. Over time, we could deprecate the use of `httptreemux.HandlerFunc` in favor of our new sub-package, but I wasn't sure if we wanted to go this route immediately, since any decision made would be difficult to revert.

**Final Note:**
I do have another branch where I do duplicate much of the code base (similar to the `contextmux` branch). Again, I wasn't sure if we wanted that route from the start. Also, I'm not fixed on the naming of `HandleWithContext`. Its a bit verbose, but, it does also convey that that main feature of `httptreemux` (the `params` map) is being implemented via a `context.Context`. 