### PR TITLE
Add mutex to protect node from concurrent access

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 )
 
 type node struct {
@@ -13,6 +14,7 @@ type node struct {
 
 	// The list of static children to check.
 	staticIndices []byte
+	mu            sync.Mutex
 	staticChild   []*node
 
 	// If none of the above match, check the wildcard children
@@ -58,6 +60,8 @@ func (n *node) setHandler(verb string, handler HandlerFunc, implicitHead bool) {
 }
 
 func (n *node) addPath(path string, wildcards []string, inStaticToken bool) *node {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	leaf := len(path) == 0
 	if leaf {
 		if wildcards != nil {

--- a/tree.go
+++ b/tree.go
@@ -45,6 +45,8 @@ func (n *node) sortStaticChild(i int) {
 }
 
 func (n *node) setHandler(verb string, handler HandlerFunc, implicitHead bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	if n.leafHandler == nil {
 		n.leafHandler = make(map[string]HandlerFunc)
 	}


### PR DESCRIPTION
When trying to add routes during runtime with go-routines, you get data races for the `staticChild`. This can be prevented with the mutex introduced in this PR. 