### PR TITLE
Add mutex to protect node.staticChild

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -242,13 +242,14 @@ func (n *node) search(method, path string) (found *node, handler HandlerFunc, pa
 	// if test != nil {
 	// 	test.Logf("Searching for %s in %s", path, n.dumpTree("", ""))
 	// }
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	pathLen := len(path)
 	if pathLen == 0 {
 		if len(n.leafHandler) == 0 {
 			return nil, nil, nil
-		} else {
-			return n, n.leafHandler[method], nil
 		}
+		return n, n.leafHandler[method], nil
 	}
 
 	// First see if this matches a static token.


### PR DESCRIPTION
This PR adds another mutex to protect `staticChild` for concurrent access. 
Additionally, I cleaned up an unnecessary `else` branch