### PR TITLE
update godoc badge to https:// URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-httptreemux  [![Build Status](https://travis-ci.org/dimfeld/httptreemux.png?branch=master)](https://travis-ci.org/dimfeld/httptreemux) [![GoDoc](http://godoc.org/github.com/dimfeld/httptreemux?status.png)](http://godoc.org/github.com/dimfeld/httptreemux)
+httptreemux  [![Build Status](https://travis-ci.org/dimfeld/httptreemux.png?branch=master)](https://travis-ci.org/dimfeld/httptreemux) [![GoDoc](https://godoc.org/github.com/dimfeld/httptreemux?status.svg)](https://godoc.org/github.com/dimfeld/httptreemux)
 ===========
 
 High-speed, flexible, tree-based HTTP router for Go.


### PR DESCRIPTION
the current http:// image no longer shows up on some mirror instances due to the mixed (https/http) content (shows a broken image). The badge is copied verbatim from https://godoc.org/github.com/dimfeld/httptreemux?tools ("Tools for package owners" link on the bottom of https://godoc.org/github.com/dimfeld/httptreemux)