### PR TITLE
Add ContextData before middleware runs

### DIFF
--- a/context.go
+++ b/context.go
@@ -58,13 +58,7 @@ func (cg *ContextGroup) NewGroup(path string) *ContextGroup {
 // Handle allows handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
 // Any parameters from the request URL are stored in a map[string]string in the request's context.
 func (cg *ContextGroup) Handle(method, path string, handler http.HandlerFunc) {
-	fullPath := cg.group.path + path
 	cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		routeData := &contextData{
-			route:  fullPath,
-			params: params,
-		}
-		r = r.WithContext(AddRouteDataToContext(r.Context(), routeData))
 		handler(w, r)
 	})
 }
@@ -72,13 +66,7 @@ func (cg *ContextGroup) Handle(method, path string, handler http.HandlerFunc) {
 // Handler allows handling HTTP requests via an http.Handler interface, as opposed to an httptreemux.HandlerFunc.
 // Any parameters from the request URL are stored in a map[string]string in the request's context.
 func (cg *ContextGroup) Handler(method, path string, handler http.Handler) {
-	fullPath := cg.group.path + path
 	cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		routeData := &contextData{
-			route:  fullPath,
-			params: params,
-		}
-		r = r.WithContext(AddRouteDataToContext(r.Context(), routeData))
 		handler.ServeHTTP(w, r)
 	})
 }

--- a/context.go
+++ b/context.go
@@ -55,20 +55,47 @@ func (cg *ContextGroup) NewGroup(path string) *ContextGroup {
 	return cg.NewContextGroup(path)
 }
 
+func (cg *ContextGroup) wrapHandler(path string, handler HandlerFunc) HandlerFunc {
+	if len(cg.group.stack) > 0 {
+		handler = handlerWithMiddlewares(handler, cg.group.stack)
+	}
+
+	//add the context data after adding all middleware
+	fullPath := cg.group.path + path
+	return func(writer http.ResponseWriter, request *http.Request, m map[string]string) {
+		routeData := &contextData{
+			route:  fullPath,
+			params: m,
+		}
+		request = request.WithContext(AddRouteDataToContext(request.Context(), routeData))
+		handler(writer, request, m)
+	}
+}
+
 // Handle allows handling HTTP requests via an http.HandlerFunc, as opposed to an httptreemux.HandlerFunc.
 // Any parameters from the request URL are stored in a map[string]string in the request's context.
 func (cg *ContextGroup) Handle(method, path string, handler http.HandlerFunc) {
-	cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+	cg.group.mux.mutex.Lock()
+	defer cg.group.mux.mutex.Unlock()
+
+	wrapped := cg.wrapHandler(path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 		handler(w, r)
 	})
+
+	cg.group.addFullStackHandler(method, path, wrapped)
 }
 
 // Handler allows handling HTTP requests via an http.Handler interface, as opposed to an httptreemux.HandlerFunc.
 // Any parameters from the request URL are stored in a map[string]string in the request's context.
 func (cg *ContextGroup) Handler(method, path string, handler http.Handler) {
-	cg.group.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+	cg.group.mux.mutex.Lock()
+	defer cg.group.mux.mutex.Unlock()
+
+	wrapped := cg.wrapHandler(path, func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 		handler.ServeHTTP(w, r)
 	})
+
+	cg.group.addFullStackHandler(method, path, wrapped)
 }
 
 // GET is convenience method for handling GET requests on a context group.

--- a/group_test.go
+++ b/group_test.go
@@ -3,7 +3,6 @@ package httptreemux
 import (
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 )
 
@@ -165,48 +164,4 @@ func TestSetGetAfterHead(t *testing.T) {
 
 	testMethod("HEAD", "HEAD")
 	testMethod("GET", "GET")
-}
-
-func TestContextDataWithMiddleware(t *testing.T) {
-	wantRoute := "/foo/:id/bar"
-	wantParams := map[string]string{
-		"id": "15",
-	}
-
-	validateRequestAndParams := func(request *http.Request, params map[string]string, location string) {
-		data := ContextData(request.Context())
-		if data == nil {
-			t.Fatalf("ContextData returned nil in %s", location)
-		}
-		if data.Route() != wantRoute {
-			t.Errorf("Unexpected route in %s.  Got %s", location, data.Route())
-		}
-		if !reflect.DeepEqual(data.Params(), wantParams) {
-			t.Errorf("Unexpected context params in %s. Got %+v", location, data.Params())
-		}
-		if !reflect.DeepEqual(params, wantParams) {
-			t.Errorf("Unexpected handler params in %s. Got %+v", location, params)
-		}
-	}
-
-	router := New()
-	router.Use(func(next HandlerFunc) HandlerFunc {
-		return func(writer http.ResponseWriter, request *http.Request, m map[string]string) {
-			validateRequestAndParams(request, m, "middleware")
-			next(writer, request, m)
-		}
-	})
-
-	router.GET(wantRoute, func(writer http.ResponseWriter, request *http.Request, m map[string]string) {
-		validateRequestAndParams(request, m, "handler")
-		writer.WriteHeader(http.StatusOK)
-	})
-
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/foo/15/bar", nil)
-	router.ServeHTTP(w, r)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("unexpected status code.  got %d", w.Code)
-	}
 }


### PR DESCRIPTION
Supersedes #81. This changes things a bit from that one to populate the Context only when a `ContextGroup` is in use, which maintains compatibility with really old Go versions and also reduces allocations by not making a Context when using the package in non-Context mode.
